### PR TITLE
Add plugin hooks and AI suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+backend/node_modules
+frontend/node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ OmniFeed is an intelligent personal dashboard for aggregating and managing multi
 
 ```bash
 docker-compose up --build
+
+Run database migrations with `npm run migrate` inside the backend directory.
 ```
 
 - Frontend: [http://localhost:3000](http://localhost:3000)
@@ -40,7 +42,13 @@ docker-compose up --build
 ## Documentation
 
 - [Agents](AGENTS.md)
+- [Workflows](docs/WORKFLOWS.md)
+- [Plugins](docs/PLUGINS.md)
 
 ## Contributing
 
 Please submit PRs against `main`. Ensure linting and tests pass before merging.
+
+## Performance Profiling
+
+Start the backend with `PROFILING=true npm run dev` to log request durations.

--- a/backend/__tests__/pluginLoader.test.js
+++ b/backend/__tests__/pluginLoader.test.js
@@ -1,0 +1,10 @@
+import express from 'express';
+import { loadPlugins } from '../pluginLoader.js';
+
+test('loadPlugins returns plugin metadata', async () => {
+  const app = express();
+  const plugins = await loadPlugins(app);
+  expect(Array.isArray(plugins)).toBe(true);
+  expect(plugins.length).toBeGreaterThan(0);
+  expect(plugins[0]).toHaveProperty('name');
+});

--- a/backend/ai/suggestions.js
+++ b/backend/ai/suggestions.js
@@ -1,0 +1,14 @@
+export function suggest(items = []) {
+  const freq = {};
+  items.forEach(i => {
+    if (!i.title) return;
+    i.title.split(/\W+/).forEach(word => {
+      const w = word.toLowerCase();
+      if (w) freq[w] = (freq[w] || 0) + 1;
+    });
+  });
+  return Object.entries(freq)
+    .sort((a,b) => b[1]-a[1])
+    .slice(0,5)
+    .map(([w]) => w);
+}

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,6 @@
+import knex from 'knex';
+import config from './knexfile.js';
+
+const db = knex(config.development);
+
+export default db;

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node'
+};

--- a/backend/knexfile.js
+++ b/backend/knexfile.js
@@ -1,0 +1,15 @@
+export default {
+  development: {
+    client: 'pg',
+    connection: process.env.DATABASE_URL || {
+      host: 'localhost',
+      port: 5432,
+      user: 'omnifeed',
+      password: 'changeme',
+      database: 'omnifeed'
+    },
+    migrations: {
+      directory: './migrations'
+    }
+  }
+};

--- a/backend/migrations/202306210001_create_filters.js
+++ b/backend/migrations/202306210001_create_filters.js
@@ -1,0 +1,12 @@
+export async function up(knex) {
+  return knex.schema.createTable('filters', table => {
+    table.increments('id').primary();
+    table.string('field');
+    table.string('operator');
+    table.string('value');
+  });
+}
+
+export async function down(knex) {
+  return knex.schema.dropTableIfExists('filters');
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,16 +1,22 @@
 {
   "name": "omnifeed-backend",
   "version": "1.0.0",
+  "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "migrate": "knex migrate:latest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },
   "dependencies": {
     "body-parser": "^1.20.1",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "knex": "^2.5.0",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
-    "nodemon": "^2.0.22"
+    "nodemon": "^2.0.22",
+    "jest": "^29.7.0"
   }
 }

--- a/backend/pluginHooks.js
+++ b/backend/pluginHooks.js
@@ -1,0 +1,16 @@
+const hooks = {
+  beforeFetch: [],
+  afterFetch: [],
+};
+
+export function registerHook(type, fn) {
+  if (hooks[type]) {
+    hooks[type].push(fn);
+  }
+}
+
+export async function runHooks(type, ...args) {
+  for (const fn of hooks[type] || []) {
+    await fn(...args);
+  }
+}

--- a/backend/pluginLoader.js
+++ b/backend/pluginLoader.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { registerHook } from './pluginHooks.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export async function loadPlugins(app) {
+  const pluginsDir = path.join(__dirname, 'plugins');
+  const loaded = [];
+  for (const file of fs.readdirSync(pluginsDir)) {
+    if (file.endsWith('.js')) {
+      const mod = await import(path.join(pluginsDir, file));
+      const plugin = mod.default || mod;
+      if (plugin && typeof plugin.register === 'function') {
+        plugin.register(app);
+        if (plugin.hooks) {
+          Object.entries(plugin.hooks).forEach(([type, fn]) => registerHook(type, fn));
+        }
+        loaded.push(plugin.meta || { name: file.replace('.js', '') });
+      }
+    }
+  }
+  return loaded;
+}

--- a/backend/plugins/customrss.js
+++ b/backend/plugins/customrss.js
@@ -1,13 +1,19 @@
 // Custom RSS plugin integration example
 
-module.exports.meta = {
+export const meta = {
   name: 'CustomRSS',
   permissions: ['read']
 };
 
-module.exports.register = function(app) {
+export const hooks = {
+  beforeFetch: async () => {
+    // placeholder for custom RSS pre-fetch logic
+  }
+};
+
+export function register(app) {
   app.post('/api/plugins/customrss/register', async (req, res) => {
     // TODO: Register custom RSS feed URL
     res.json({ success: true });
   });
-};
+}

--- a/backend/plugins/newsapi.js
+++ b/backend/plugins/newsapi.js
@@ -1,13 +1,19 @@
 // NewsAPI plugin integration example
 
-module.exports.meta = {
+export const meta = {
   name: 'NewsAPI',
   permissions: ['read']
 };
 
-module.exports.register = function(app) {
+export const hooks = {
+  afterFetch: async () => {
+    // placeholder for NewsAPI post-fetch logic
+  }
+};
+
+export function register(app) {
   app.get('/api/plugins/newsapi/articles', async (req, res) => {
     // TODO: Fetch articles from NewsAPI.org
     res.json({ articles: [] });
   });
-};
+}

--- a/backend/plugins/xcom.js
+++ b/backend/plugins/xcom.js
@@ -1,13 +1,19 @@
 // x.com plugin integration example
 
-module.exports.meta = {
+export const meta = {
   name: 'x.com',
   permissions: ['read']
 };
 
-module.exports.register = function(app) {
+export const hooks = {
+  afterFetch: async () => {
+    // placeholder for x.com post-fetch logic
+  }
+};
+
+export function register(app) {
   app.get('/api/plugins/xcom/feed', async (req, res) => {
     // TODO: Fetch and return x.com feed items
     res.json({ items: [] });
   });
-};
+}

--- a/backend/profiling.js
+++ b/backend/profiling.js
@@ -1,0 +1,10 @@
+import { performance } from 'perf_hooks';
+
+export function profileMiddleware(req, res, next) {
+  const start = performance.now();
+  res.on('finish', () => {
+    const duration = performance.now() - start;
+    console.log(`[PROFILE] ${req.method} ${req.url} ${duration.toFixed(2)}ms`);
+  });
+  next();
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,76 +1,62 @@
 import express from 'express';
 import path from 'path';
-import fs from 'fs';
+import { fileURLToPath } from 'url';
 import bodyParser from 'body-parser';
+import { loadPlugins } from './pluginLoader.js';
+import { suggest } from './ai/suggestions.js';
+import db from './db.js';
+import { profileMiddleware } from './profiling.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const app = express();
 app.use(bodyParser.json());
 
-// Runtime plugin loader
-const pluginsDir = path.join(__dirname, 'plugins');
-fs.readdirSync(pluginsDir).forEach((file) => {
-  if (file.endsWith('.js')) {
-    const plugin = require(path.join(pluginsDir, file));
-    if (plugin && plugin.register) {
-      plugin.register(app);
-    }
-  }
-});
+if (process.env.PROFILING === 'true') {
+  app.use(profileMiddleware);
+}
+
+// Load plugins
+const loadedPlugins = await loadPlugins(app);
+app.get('/api/plugins', (req, res) => res.json(loadedPlugins));
 
 // Workflow endpoints
 app.post('/api/workflows/music-fetcher', (req, res) => {
-  //Proxy to n8n webhook for MusicFetcher
-  res.status(200).json({message:'MusicFetcher workflow triggered', data:req.body});
+  res.status(200).json({ message: 'MusicFetcher workflow triggered', data: req.body });
 });
 app.post('/api/workflows/rss-ingestor', (req, res) => {
-  res.status(200).json({message:'RSSIngestor workflow triggered', data:req.body});
+  res.status(200).json({ message: 'RSSIngestor workflow triggered', data: req.body });
 });
 app.post('/api/workflows/podcast-tracker', (req, res) => {
-  res.status(200).json({message:'PodcastTracker workflow triggered', data:req.body});
+  res.status(200).json({ message: 'PodcastTracker workflow triggered', data: req.body });
 });
 app.post('/api/workflows/youtube-subscriptions', (req, res) => {
-  res.status(200).json({message:'YouTubeSubscriptions workflow triggered', data:req.body});
+  res.status(200).json({ message: 'YouTubeSubscriptions workflow triggered', data: req.body });
+});
+
+// AI suggestions endpoint
+app.post('/api/suggestions', (req, res) => {
+  const suggestions = suggest(req.body.items || []);
+  res.json({ suggestions });
 });
 
 // Smart Filters CRUD
-let filters = [];
-app.get('/api/filters', (req, res) => res.json(filters));
-app.post('/api/filters', (req, res) => {
-  const filter = {...req.body, id:Date.now()};
-  filters.push(filter);
+app.get('/api/filters', async (req, res) => {
+  const filters = await db('filters').select();
+  res.json(filters);
+});
+app.post('/api/filters', async (req, res) => {
+  const [filter] = await db('filters').insert(req.body).returning('*');
   res.json(filter);
 });
-app.put('/api/filters/:id', (req, res) => {
-  const id = Number(req.params.id);
-  filters = filters.map(f => f.id===id?{...f,...req.body}:f);
-  res.json(filters.find(f=>f.id===id));
+app.put('/api/filters/:id', async (req, res) => {
+  const [filter] = await db('filters').where({ id: req.params.id }).update(req.body).returning('*');
+  res.json(filter);
 });
-app.delete('/api/filters/:id', (req, res) => {
-  const id = Number(req.params.id);
-  filters = filters.filter(f=>f.id!==id);
-  res.json({deleted:id});
+app.delete('/api/filters/:id', async (req, res) => {
+  await db('filters').where({ id: req.params.id }).del();
+  res.json({ deleted: Number(req.params.id) });
 });
-
-// Plugin manager endpoint
-/**
- * @typedef {Object} PluginInfo
- * @property {string} name
- * @property {string[]} permissions
- */
-/** @type {PluginInfo[]} */
-let loadedPlugins = [];
-app.get('/api/plugins', (req,res)=>res.json(loadedPlugins));
-
-// Load plugin metadata
-defaultPlugins();
-function defaultPlugins() {
-  fs.readdirSync(pluginsDir).forEach((file) => {
-    if (file.endsWith('.js')) {
-      const meta = require(path.join(pluginsDir, file)).meta;
-      if (meta) loadedPlugins.push(meta);
-    }
-  });
-}
 
 // Serve static
 app.use(express.static(path.join(__dirname, '../frontend/dist')));

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,16 @@
+# Writing Plugins
+
+Plugins extend the dashboard with new integrations. Each plugin exports `meta`, `register`, and optional `hooks`:
+
+```js
+module.exports.meta = { name: 'MyPlugin', permissions: ['read'] };
+module.exports.hooks = { beforeFetch() { /* ... */ } };
+module.exports.register = function(app) {
+  app.get('/api/plugins/myplugin/action', async (req, res) => {
+    res.json({ ok: true });
+  });
+};
+```
+
+Place plugin files in `backend/plugins/` and restart the backend to load them.
+Unit tests can target plugin hooks using Jest.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,10 @@
+# n8n Workflows
+
+This section outlines how to create and update workflows used by OmniFeed.
+
+1. Open the n8n editor at `http://localhost:5678` and create a new workflow.
+2. Configure triggers and nodes to fetch external content.
+3. Save the workflow as JSON under `backend/workflows/`.
+4. Expose the workflow via the backend by adding an endpoint in `server.js`.
+
+Workflows can be versioned and stored in source control for easier collaboration.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": ""
   },
   "dependencies": {
     "react": "^19.1.0",


### PR DESCRIPTION
## Summary
- add plugin loading contract and hook utilities
- integrate simple AI suggestions endpoint
- persist filters via Knex migrations
- document workflows and plugin writing
- add basic Jest test for plugin loading
- note profiling instructions

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_685663bf87108326a0aac160bce151b8